### PR TITLE
Show package product details

### DIFF
--- a/app/Http/Controllers/PaqueteController.php
+++ b/app/Http/Controllers/PaqueteController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Paquete;
+use App\Models\Producto;
 use Illuminate\Http\Request;
 
 class PaqueteController extends Controller
@@ -11,6 +12,17 @@ class PaqueteController extends Controller
     {
         try {
             $paquetes = Paquete::all();
+
+            // Adjuntar la información de los productos a cada paquete
+            $paquetes->transform(function ($paquete) {
+                $ids = is_array($paquete->productos)
+                    ? $paquete->productos
+                    : json_decode($paquete->productos, true);
+
+                $paquete->productos_detalle = Producto::whereIn('_id', $ids)->get();
+                return $paquete;
+            });
+
             return response()->json($paquetes);
         } catch (\Exception $e) {
             return response()->json(['error' => 'Error al obtener paquetes'], 500);
@@ -41,6 +53,13 @@ class PaqueteController extends Controller
     {
         try {
             $paquete = Paquete::findOrFail($id);
+
+            $ids = is_array($paquete->productos)
+                ? $paquete->productos
+                : json_decode($paquete->productos, true);
+
+            $paquete->productos_detalle = Producto::whereIn('_id', $ids)->get();
+
             return response()->json($paquete);
         } catch (\Exception $e) {
             return response()->json(['error' => 'Paquete no encontrado'], 404);

--- a/resources/js/PackageApp.jsx
+++ b/resources/js/PackageApp.jsx
@@ -425,6 +425,23 @@ function PackageApp() {
                                         <p className="text-sm text-gray-500">
                                             {paquete.descripcion}
                                         </p>
+                                        {Array.isArray(paquete.productos_detalle) && (
+                                            <ul className="mt-2 space-y-1 pl-4 list-disc">
+                                                {paquete.productos_detalle.map((prod) => (
+                                                    <li key={prod._id || prod.id} className="flex items-center space-x-2">
+                                                        {prod.imagenes && prod.imagenes.length > 0 && (
+                                                            <img
+                                                                src={`/storage/${prod.imagenes[0]}`}
+                                                                alt={prod.nombre}
+                                                                className="w-6 h-6 object-cover rounded"
+                                                                onError={(e) => (e.target.style.display = 'none')}
+                                                            />
+                                                        )}
+                                                        <span>{prod.nombre}</span>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
                                         <button
                                             onClick={() => handleEditPackage(paquete._id || paquete.id)}
                                             className="text-blue-500 hover:text-blue-700 hover:bg-blue-100 p-1 rounded-full transition-colors text-sm"


### PR DESCRIPTION
## Summary
- include product info when listing packages
- display images and names of products inside each package

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ba01abd88320bb26914060ba2ae6